### PR TITLE
litepciedrv: Device: fix invalid 64-bit logical addresses for 32-bit DMA device

### DIFF
--- a/litepciedrv/src/Device.c
+++ b/litepciedrv/src/Device.c
@@ -274,7 +274,13 @@ NTSTATUS litepciedrv_DeviceOpen(WDFDEVICE wdfDevice,
     WdfDeviceSetAlignmentRequirement(litepcie->deviceDrv, FILE_LONG_ALIGNMENT);
 
     WDF_DMA_ENABLER_CONFIG dmaConfig;
-    WDF_DMA_ENABLER_CONFIG_INIT(&dmaConfig, WdfDmaProfileScatterGather64Duplex, DMA_BUFFER_SIZE);
+    WDF_DMA_ENABLER_CONFIG_INIT(&dmaConfig,
+#if DMA_ADDR_WIDTH > 32
+            WdfDmaProfileScatterGather64Duplex,
+#else
+            WdfDmaProfileScatterGatherDuplex,
+#endif
+            DMA_BUFFER_SIZE);
     status = WdfDmaEnablerCreate(litepcie->deviceDrv, &dmaConfig, WDF_NO_OBJECT_ATTRIBUTES, &litepcie->dmaEnabler);
     if (!NT_SUCCESS(status)) {
         TraceEvents(TRACE_LEVEL_ERROR, TRACE_DEVICE, "Failed to create dmaEnabler: %!STATUS!", status);


### PR DESCRIPTION
This updates the WDFEnabler profile to WdfDmaProfileScatterGatherDuplex for 32-bit addressable DMA device. This corrects the bus<->physical address mapping of the reader/writer common buffer.